### PR TITLE
Release hubExamples 1.0.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubExamples
 Title: Example Hub Data
-Version: 1.0.0.9000
+Version: 1.0.1
 Authors@R: c(
     person(given = "Evan L",
            family = "Ray",
@@ -19,7 +19,12 @@ Authors@R: c(
            family = "Contamin",
            email = "contamin@pitt.edu",
            comment = c(ORCID = "0000-0001-5797-1279"),
-           role = c("aut")))
+           role = c("aut")),
+    person(given = "Anna",
+           family = "Krystalli",
+           email = "annakrystalli@googlemail.com",
+           comment = c(ORCID = "0000-0002-2378-4915"),
+           role = c("ctb")))
 Description: This package provides example data for forecasting and scenario
     modeling hubs in the hubverse format.
 License: MIT + file LICENSE

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
-# hubExamples (development version)
+# hubExamples 1.0.1
 
-* Regenerate `forecast_outputs` without arrow ALTREP-backed columns so the `.rda` deserialises correctly on systems where `arrow` is not installed (#63). The `data-raw` scripts now set `options(arrow.use_altrep = FALSE)` so future regenerations stay portable.
+* Fix `forecast_outputs` deserialising as length-zero columns on systems without `arrow` installed (#63).
 
 # hubExamples 1.0.0
 


### PR DESCRIPTION
## Summary

Patch release of hubExamples following https://github.com/hubverse-org/hubExamples/pull/64.

### Changes since 1.0.0

* Fix `forecast_outputs` deserialising as length-zero columns on systems without `arrow` installed (#63).

### Other release prep

* Add Anna Krystalli to `Authors@R` as contributor (`ctb`).